### PR TITLE
#3 - spock에서 stubbing 하는 위치에 대한 의문

### DIFF
--- a/src/test/groovy/com/example/springapi/api/service/KakaoAddressSearchServiceRetryTest.groovy
+++ b/src/test/groovy/com/example/springapi/api/service/KakaoAddressSearchServiceRetryTest.groovy
@@ -45,17 +45,18 @@ class KakaoAddressSearchServiceRetryTest extends AbstractIntegrationContainerBas
                 .build()
         def expectedResponse = new KakaoApiResponseDto(metaDto, Arrays.asList(documentDto))
         def uri = mockWebServer.url("/").uri()
+
+        when:
         mockWebServer.enqueue(new MockResponse().setResponseCode(504))
         mockWebServer.enqueue(new MockResponse().setResponseCode(200)
                 .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .setBody(mapper.writeValueAsString(expectedResponse)))
 
-        when:
-        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
-
         def kakaoApiResult = kakaoAddressSearchService.requestAddressSearch(inputAddress)
 
         then:
+        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
+
         kakaoApiResult.getDocumentList().size() == 1
         kakaoApiResult.getMetaDto().totalCount == 1
         kakaoApiResult.getDocumentList().get(0).getAddressName() == inputAddress
@@ -71,11 +72,11 @@ class KakaoAddressSearchServiceRetryTest extends AbstractIntegrationContainerBas
         mockWebServer.enqueue(new MockResponse().setResponseCode(504))
         mockWebServer.enqueue(new MockResponse().setResponseCode(504))
 
-        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
-
         def result = kakaoAddressSearchService.requestAddressSearch(inputAddress)
 
         then:
+        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
+
         result == null
     }
 


### PR DESCRIPTION
spock에서 JUnit mockito 테스트 코드를 작성하는 것 처럼 given절에 stubbing, then절에 mocking 하는 코드를 작성하게 되면 테스트를 실패하게 된다.
이유는 spock은 then block내에 존재하는 mocking(+ stubbing) 구문을 파악 후 when block 앞으로 이동시켜주기 때문이다.
즉, 런타임시 mocking 구문이 when block 앞으로 이동되고 결국 then block 안에 두어도 문제가 발생하지 않게 된다.

내가 처음에 품었던 의문대로 mocking 구문을 given 혹은 when block에 이동 시켜도 문제는 없으나 MissingPropertyException  에 대한 에러를 생각해야 한다.
이는 아래 참고한 문서들에서 설명을 하고 있으니 참고 바란다.
[spock doc](https://spockframework.org/spock/docs/1.0/interaction_based_testing.html)
[spock 사용시 주의사항](https://pompitzz.github.io/blog/Groovy/spock-summary.html#helper-method%E1%84%8B%E1%85%A6%E1%84%82%E1%85%B3%E1%86%AB-def%E1%84%80%E1%85%A1-%E1%84%8B%E1%85%A1%E1%84%82%E1%85%B5%E1%86%AB-void)

this closes #3 